### PR TITLE
Reimplement the tokio-core example

### DIFF
--- a/impls/tokio-core/Cargo.lock
+++ b/impls/tokio-core/Cargo.lock
@@ -3,7 +3,6 @@ name = "tokio-core-zillions"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/impls/tokio-core/Cargo.toml
+++ b/impls/tokio-core/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["David Renshaw <david@sandstorm.io>"]
 [dependencies]
 futures = "0.1.1"
 tokio-core = "0.1"
-slab = "0.3"
 
 [[bin]]
 name="server"

--- a/impls/tokio-core/server.rs
+++ b/impls/tokio-core/server.rs
@@ -1,290 +1,147 @@
-extern crate slab;
-
 #[macro_use]
 extern crate futures;
-
-#[macro_use]
 extern crate tokio_core;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::env;
+use std::io;
+use std::iter;
 use std::net::SocketAddr;
 use std::rc::Rc;
-use std::cell::{RefCell};
 
-use slab::Slab;
-use futures::{Async, Poll, Future};
-use futures::stream::Stream;
-use tokio_core::io::{Io};
-use tokio_core::net::TcpListener;
-use tokio_core::reactor::Core;
+use futures::Future;
+use futures::stream::{self, Stream};
+use tokio_core::channel::{channel, Sender};
+use tokio_core::io::{read_exact, write_all, Io};
+use tokio_core::net::{TcpListener, TcpStream};
+use tokio_core::reactor::{Core, Handle};
 
-struct ReadStream<R> where R: ::std::io::Read {
-    reader: R,
-    buffer: Vec<u8>,
-    pos: usize,
-    frame_end: Option<u8>,
-}
+const MAX_BUFFERED: usize = 5;
 
-impl <R> ReadStream<R> where R: ::std::io::Read {
-    fn new(reader: R) -> ReadStream<R> {
-        ReadStream {
-            reader: reader,
-            buffer: Vec::new(),
-            pos: 0,
-            frame_end: None,
-        }
-    }
-}
+fn main() {
+    // Parse out what address we're going to listen on, defaulting to "something
+    // reasonable"
+    let addr = env::args().skip(1).next();
+    let addr = addr.unwrap_or("127.0.0.1:8080".to_string());
+    let addr: SocketAddr = addr.parse().unwrap();
 
-impl <R> Stream for ReadStream<R> where R: ::std::io::Read {
-    type Item = Vec<u8>;
-    type Error = ::std::io::Error;
-
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            if let Some(frame_end) = self.frame_end {
-                let n = try_nb!(self.reader.read(&mut self.buffer[self.pos..frame_end as usize]));
-                self.pos += n;
-                if self.pos == frame_end as usize {
-                    self.pos = 0;
-                    let result = ::std::mem::replace(&mut self.buffer, Vec::new());
-                    self.frame_end = None;
-                    return Ok(Async::Ready(Some(result)))
-                }
-            } else {
-                let mut buf = [0u8];
-                let n = try_nb!(self.reader.read(&mut buf));
-                if n == 0 { // EOF
-                    return Ok(Async::Ready(None))
-                }
-
-                self.frame_end = Some(buf[0]);
-                self.buffer = vec![0; buf[0] as usize];
-            }
-        }
-    }
-}
-
-pub fn main() {
-    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
-    let addr = addr.parse::<SocketAddr>().unwrap();
-
-    let mut l = Core::new().unwrap();
-    let handle = l.handle();
-
-    // Create a TCP listener which will listen for incoming connections
-    let socket = TcpListener::bind(&addr, &handle).unwrap();
-
-    // Once we've got the TCP listener, inform that we have it
+    // Create the global state of our program. This involves the event loop (a
+    // `Core`) to run all our I/O on, a TCP listener which we're going to accept
+    // connections form, and finally the global hash map we're storing all
+    // connection state in.
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+    let srv = TcpListener::bind(&addr, &handle).unwrap();
     println!("listening on {}", addr);
+    let map = Rc::new(RefCell::new(HashMap::new()));
 
-    let subscribers: Rc<RefCell<Slab<::write_queue::Sender, usize>>> =
-        Rc::new(RefCell::new(Slab::with_capacity(1024)));
-
-    let done = socket.incoming().for_each(move |(socket, _addr)| {
-        let subscribers = subscribers.clone();
-
-        let future = futures::lazy(|| Ok(socket.split())).and_then(|(reader, writer)| {
-            let subscribers1 = subscribers.clone();
-            let read = ReadStream::new(reader).for_each(move |buf| {
-                for ref mut sender in subscribers1.borrow_mut().iter_mut() {
-                    if sender.len() < 5 {
-                        drop(sender.send(buf.clone()));
-                    }
-                }
-                Ok(())
-            });
-
-            let (sender, queue) = ::write_queue::write_queue(writer);
-            if !subscribers.borrow().has_available() {
-                let len = subscribers.borrow().len();
-                subscribers.borrow_mut().reserve_exact(len);
-            }
-            let idx = match subscribers.borrow_mut().insert(sender) {
-                Ok(idx) => idx,
-                Err(_) => unreachable!(),
-            };
-
-
-            Box::new(read.select(queue.map(|_|())).then(move |_| {
-                subscribers.borrow_mut().remove(idx).unwrap();
-                Ok(())
-            }))
-        });
-
-        handle.spawn(future);
-
+    // Create a small loop which will spawn off a new task for all accepted
+    // connections. Each task will handle the messages for that connection
+    // specifically, as well as listening for messages from other connections.
+    //
+    // Note that `futures::lazy` here is used for the call to `Io::split` below
+    // in the `client` function, but it can mostly just be ignored.
+    let srv = srv.incoming().for_each(|(socket, addr)| {
+        let handle2 = handle.clone();
+        let map = map.clone();
+        handle.spawn(futures::lazy(move || {
+            client(socket, &handle2, addr, map)
+        }));
         Ok(())
     });
 
-    l.run(done).unwrap();
+    core.run(srv).unwrap();
 }
 
-pub mod write_queue {
-    use std::collections::VecDeque;
-    use std::rc::Rc;
-    use std::cell::RefCell;
-    use futures::{self, task, Async, Future, Poll, Complete, Oneshot};
-    use tokio_core::io::WriteAll;
+/// Internal state saved for each client.
+///
+/// The "global hash map" is a hash of socket addresses to instances of this
+/// type. An instance is available for all connected clients.
+struct Client {
+    // A channel to send messages over to be received and written out.
+    tx: Sender<Vec<u8>>,
 
-    enum State<W> where W: ::std::io::Write {
-        WritingHeader(W, Vec<u8>, Complete<Vec<u8>>),
-        Writing(WriteAll<W, Vec<u8>>, Complete<Vec<u8>>),
-        BetweenWrites(W),
-        Empty,
-    }
+    // Current number of pending messages. If too many messages are pending then
+    // messages to this client are dropped on the floor.
+    size: usize,
+}
 
-    /// A write of messages being written.
-    pub struct WriteQueue<W> where W: ::std::io::Write {
-        inner: Rc<RefCell<Inner>>,
-        state: State<W>,
-    }
+fn client(socket: TcpStream,
+          handle: &Handle,
+          addr: SocketAddr,
+          map: Rc<RefCell<HashMap<SocketAddr, Client>>>)
+          -> Box<Future<Item=(), Error=()>> {
+    // First up, register our new client by creating an entry in the global
+    // state map.
+    let (tx, rx) = channel(handle).unwrap();
+    assert!(map.borrow_mut().insert(addr, Client {
+        tx: tx,
+        size: 0,
+    }).is_none());
 
-    struct Inner {
-        queue: VecDeque<(Vec<u8>, Complete<Vec<u8>>)>,
-        sender_count: usize,
-        task: Option<task::Task>,
-    }
+    // Next, we call the `Io::split` function here to easily work with both
+    // halves of the socket as an instance of `Read` and `Write`. This'll allow
+    // us to independently define the logic below without having to worry about
+    // Rust's ownership of the original value.
+    let (reader, writer) = socket.split();
 
-    pub struct Sender {
-        inner: Rc<RefCell<Inner>>,
-    }
+    // Here we define how to read the socket. A small infinite iterator is
+    // created to form a loop over reading messages off the socket. We use the
+    // `read_exact` combinator to read messages from the socket, and once a
+    // message is read it's dispatched to all other clients.
+    //
+    // Note that once a message is read we finish one iteration of the `fold`
+    // and the reader is then passed on to the next to execute.
+    //
+    // Also note that this is where the backpressure logic for connected clients
+    // comes into play. We don't send messages to clients that have too many
+    // messages queued up already.
+    let map2 = map.clone();
+    let infinite = stream::iter(iter::repeat(()).map(Ok::<(), io::Error>));
+    let reader = infinite.fold(reader, move |reader, ()| {
+        let size = read_exact(reader, [0u8]);
 
-    impl Clone for Sender {
-        fn clone(&self) -> Sender {
-            self.inner.borrow_mut().sender_count += 1;
-            Sender { inner: self.inner.clone() }
-        }
-    }
+        let msg = size.and_then(|(rd, size)| {
+            let buf = vec![0u8; size[0] as usize];
+            read_exact(rd, buf)
+        });
 
-    impl Drop for Sender {
-        fn drop(&mut self) {
-            self.inner.borrow_mut().sender_count -= 1;
-        }
-    }
-
-    pub fn write_queue<W>(writer: W) -> (Sender, WriteQueue<W>)
-        where W: ::std::io::Write
-    {
-        let inner = Rc::new(RefCell::new(Inner {
-            queue: VecDeque::new(),
-            task: None,
-            sender_count: 1,
-        }));
-
-        let queue = WriteQueue {
-            inner: inner.clone(),
-            state: State::BetweenWrites(writer),
-        };
-
-        let sender = Sender { inner: inner };
-
-        (sender, queue)
-    }
-
-    impl Sender {
-        /// Enqueues a message to be written.
-        pub fn send(&mut self, message: Vec<u8>) -> Oneshot<Vec<u8>> {
-            let (complete, oneshot) = futures::oneshot();
-            self.inner.borrow_mut().queue.push_back((message, complete));
-
-            match self.inner.borrow_mut().task.take() {
-                Some(t) => t.unpark(),
-                None => (),
-            }
-
-            oneshot
-        }
-
-        /// Returns the number of messages queued to be written, not including any in-progress write.
-        pub fn len(&mut self) -> usize {
-            self.inner.borrow().queue.len()
-        }
-    }
-
-    enum IntermediateState<W> where W: ::std::io::Write {
-        WriteHeaderDone,
-        WriteDone(Vec<u8>, W),
-        StartWrite(Vec<u8>, Complete<Vec<u8>>),
-        Resolve,
-    }
-
-    impl <W> Future for WriteQueue<W> where W: ::std::io::Write {
-        type Item = W; // Resolves when all senders have been dropped and all messages written.
-        type Error = ::std::io::Error;
-
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            loop {
-                let next = match self.state {
-                    State::WritingHeader(ref mut write, ref buf, ref mut _complete) => {
-                        let n = try_nb!(write.write(&[buf.len() as u8]));
-                        match n {
-                            0 => unimplemented!(), // TODO return error premature EOF
-                            1 => IntermediateState::WriteHeaderDone,
-                            _ => unreachable!(),
-                        }
-                    }
-                    State::Writing(ref mut write, ref mut _complete) => {
-                        let (w, m) = try_ready!(Future::poll(write));
-                        IntermediateState::WriteDone(m, w)
-                    }
-                    State::BetweenWrites(ref mut _writer) => {
-                        let front = self.inner.borrow_mut().queue.pop_front();
-                        match front {
-                            Some((m, complete)) => {
-                                IntermediateState::StartWrite(m, complete)
-                            }
-                            None => {
-                                let count = self.inner.borrow().sender_count;
-                                if count == 0 {
-                                    IntermediateState::Resolve
-                                } else {
-                                    self.inner.borrow_mut().task = Some(task::park());
-                                    return Ok(Async::NotReady)
-                                }
-                            }
-                        }
-                    }
-                    State::Empty => unreachable!(),
-                };
-
-                match next {
-                    IntermediateState::WriteHeaderDone => {
-                        let new_state = match ::std::mem::replace(&mut self.state, State::Empty) {
-                            State::WritingHeader(writer, buf, complete) => {
-                                State::Writing(::tokio_core::io::write_all(writer, buf), complete)
-                            }
-                            _ => unreachable!(),
-                        };
-                        self.state = new_state;
-                    }
-                    IntermediateState::WriteDone(m, w) => {
-                        match ::std::mem::replace(&mut self.state, State::BetweenWrites(w)) {
-                            State::Writing(_, complete) => {
-                                complete.complete(m)
-                            }
-                            _ => unreachable!(),
-                        }
-                    }
-                    IntermediateState::StartWrite(m, c) => {
-                        let new_state = match ::std::mem::replace(&mut self.state, State::Empty) {
-                            State::BetweenWrites(w) => {
-                                State::WritingHeader(w, m, c)
-                            }
-                            _ => unreachable!(),
-                        };
-                        self.state = new_state;
-                    }
-                    IntermediateState::Resolve => {
-                        match ::std::mem::replace(&mut self.state, State::Empty) {
-                            State::BetweenWrites(w) => {
-                                return Ok(Async::Ready(w))
-                            }
-                            _ => unreachable!(),
-                        }
-                    }
+        let map = map2.clone();
+        msg.map(move |(rd, buf)| {
+            for peer in map.borrow_mut().values_mut() {
+                if peer.size < MAX_BUFFERED {
+                    peer.size += 1;
+                    peer.tx.send(buf.clone()).unwrap();
                 }
             }
-        }
-    }
+            rd
+        })
+    });
+
+    // Here we define how to write messages to our client. This simply involves
+    // iterating over all messages coming off the channel and writing them out
+    // as per our protocol.
+    let map2 = map.clone();
+    let writer = rx.fold(writer, move |writer, msg| {
+        map2.borrow_mut().get_mut(&addr).unwrap().size -= 1;
+        write_all(writer, [msg.len() as u8]).and_then(|(wr, _)| {
+            write_all(wr, msg).map(|p| p.0)
+        })
+    });
+
+    // Finally, we `select` over the read and the write halves. This means that
+    // once either hits an error or finishes we're done. Note that the most
+    // likely thing to happen here is the `reader` hits an error due to EOF (in
+    // line with our use of `read_exact` above) which will cause the `select`
+    // future to resolve.
+    //
+    // Once the reader/writer halves are done, we deregister ourselves from the
+    // global map of connections. to free up our resources.
+    let reader = reader.map(|_| ()).map_err(|_| ());
+    let writer = writer.map(|_| ()).map_err(|_| ());
+    Box::new(reader.select(writer).then(move |_| {
+        assert!(map.borrow_mut().remove(&addr).is_some());
+        Ok(())
+    }))
 }


### PR DESCRIPTION
Use the various combinators in `tokio_core::io` instead of writing
futures ourselves, and helps tighten up the implementation a bit as
well!
